### PR TITLE
Playing tag

### DIFF
--- a/src/main/resources/data/forge/tags/blocks/ores.json
+++ b/src/main/resources/data/forge/tags/blocks/ores.json
@@ -1,7 +1,7 @@
 {
   "replace": false,
   "values": [
-    "oreganized:lead_ore",
-    "oreganized:silver_ore"
+    "#forge:ores/lead",
+    "#forge:ores/silver"
   ]
 }

--- a/src/main/resources/data/forge/tags/blocks/ores/lead.json
+++ b/src/main/resources/data/forge/tags/blocks/ores/lead.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:lead_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/ores/silver.json
+++ b/src/main/resources/data/forge/tags/blocks/ores/silver.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:silver_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:storage_blocks/silver"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/silver.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/silver.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:silver_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass/black.json
+++ b/src/main/resources/data/forge/tags/items/glass/black.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:black_crystal_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass/blue.json
+++ b/src/main/resources/data/forge/tags/items/glass/blue.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:blue_crystal_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass/brown.json
+++ b/src/main/resources/data/forge/tags/items/glass/brown.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:brown_crystal_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass/colorless.json
+++ b/src/main/resources/data/forge/tags/items/glass/colorless.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:crystal_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass/cyan.json
+++ b/src/main/resources/data/forge/tags/items/glass/cyan.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:cyan_crystal_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass/gray.json
+++ b/src/main/resources/data/forge/tags/items/glass/gray.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:gray_crystal_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass/green.json
+++ b/src/main/resources/data/forge/tags/items/glass/green.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:green_crystal_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass/light_blue.json
+++ b/src/main/resources/data/forge/tags/items/glass/light_blue.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:light_blue_crystal_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass/light_gray.json
+++ b/src/main/resources/data/forge/tags/items/glass/light_gray.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:light_gray_crystal_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass/lime.json
+++ b/src/main/resources/data/forge/tags/items/glass/lime.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:lime_crystal_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass/magenta.json
+++ b/src/main/resources/data/forge/tags/items/glass/magenta.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:magenta_crystal_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass/orange.json
+++ b/src/main/resources/data/forge/tags/items/glass/orange.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:orange_crystal_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass/pink.json
+++ b/src/main/resources/data/forge/tags/items/glass/pink.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:pink_crystal_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass/purple.json
+++ b/src/main/resources/data/forge/tags/items/glass/purple.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:purple_crystal_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass/red.json
+++ b/src/main/resources/data/forge/tags/items/glass/red.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:red_crystal_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass/white.json
+++ b/src/main/resources/data/forge/tags/items/glass/white.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:white_crystal_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass/yellow.json
+++ b/src/main/resources/data/forge/tags/items/glass/yellow.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:yellow_crystal_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass_panes/black.json
+++ b/src/main/resources/data/forge/tags/items/glass_panes/black.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:black_crystal_glass_pane"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass_panes/blue.json
+++ b/src/main/resources/data/forge/tags/items/glass_panes/blue.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:blue_crystal_glass_pane"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass_panes/brown.json
+++ b/src/main/resources/data/forge/tags/items/glass_panes/brown.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:brown_crystal_glass_pane"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass_panes/colorless.json
+++ b/src/main/resources/data/forge/tags/items/glass_panes/colorless.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:crystal_glass_pane"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass_panes/cyan.json
+++ b/src/main/resources/data/forge/tags/items/glass_panes/cyan.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:cyan_crystal_glass_pane"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass_panes/gray.json
+++ b/src/main/resources/data/forge/tags/items/glass_panes/gray.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:gray_crystal_glass_pane"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass_panes/green.json
+++ b/src/main/resources/data/forge/tags/items/glass_panes/green.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:green_crystal_glass_pane"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass_panes/light_blue.json
+++ b/src/main/resources/data/forge/tags/items/glass_panes/light_blue.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:light_blue_crystal_glass_pane"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass_panes/light_gray.json
+++ b/src/main/resources/data/forge/tags/items/glass_panes/light_gray.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:light_gray_crystal_glass_pane"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass_panes/lime.json
+++ b/src/main/resources/data/forge/tags/items/glass_panes/lime.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:lime_crystal_glass_pane"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass_panes/magenta.json
+++ b/src/main/resources/data/forge/tags/items/glass_panes/magenta.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:magenta_crystal_glass_pane"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass_panes/orange.json
+++ b/src/main/resources/data/forge/tags/items/glass_panes/orange.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:orange_crystal_glass_pane"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass_panes/pink.json
+++ b/src/main/resources/data/forge/tags/items/glass_panes/pink.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:pink_crystal_glass_pane"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass_panes/purple.json
+++ b/src/main/resources/data/forge/tags/items/glass_panes/purple.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:purple_crystal_glass_pane"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass_panes/red.json
+++ b/src/main/resources/data/forge/tags/items/glass_panes/red.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:red_crystal_glass_pane"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass_panes/white.json
+++ b/src/main/resources/data/forge/tags/items/glass_panes/white.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:white_crystal_glass_pane"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass_panes/yellow.json
+++ b/src/main/resources/data/forge/tags/items/glass_panes/yellow.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:yellow_crystal_glass_pane"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ingots.json
+++ b/src/main/resources/data/forge/tags/items/ingots.json
@@ -1,7 +1,7 @@
 {
   "replace": false,
   "values": [
-    "oreganized:lead_ingot",
-    "oreganized:silver_ingot"
+    "#forge:ingots/lead",
+    "#forge:ingots/silver",
   ]
 }

--- a/src/main/resources/data/forge/tags/items/ingots.json
+++ b/src/main/resources/data/forge/tags/items/ingots.json
@@ -2,6 +2,6 @@
   "replace": false,
   "values": [
     "#forge:ingots/lead",
-    "#forge:ingots/silver",
+    "#forge:ingots/silver"
   ]
 }

--- a/src/main/resources/data/forge/tags/items/ingots/lead.json
+++ b/src/main/resources/data/forge/tags/items/ingots/lead.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:lead_ingot"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ingots/silver.json
+++ b/src/main/resources/data/forge/tags/items/ingots/silver.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:silver_ingot"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/nuggets.json
+++ b/src/main/resources/data/forge/tags/items/nuggets.json
@@ -1,8 +1,8 @@
 {
   "replace": false,
   "values": [
-    "oreganized:lead_nugget",
-    "oreganized:netherite_nugget",
-    "oreganized:silver_nugget"
+    "#forge:nuggets/lead",
+    "#forge:nuggets/silver",
+    "#forge:nuggets/netherite"
   ]
 }

--- a/src/main/resources/data/forge/tags/items/nuggets/lead.json
+++ b/src/main/resources/data/forge/tags/items/nuggets/lead.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:lead_nugget"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/nuggets/netherite.json
+++ b/src/main/resources/data/forge/tags/items/nuggets/netherite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:netherite_nugget"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/nuggets/silver.json
+++ b/src/main/resources/data/forge/tags/items/nuggets/silver.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:silver_nugget"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores.json
+++ b/src/main/resources/data/forge/tags/items/ores.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:ores/lead",
+    "#forge:ores/silver"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores/lead.json
+++ b/src/main/resources/data/forge/tags/items/ores/lead.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:lead_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores/silver.json
+++ b/src/main/resources/data/forge/tags/items/ores/silver.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:silver_ore"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/slabs.json
+++ b/src/main/resources/data/minecraft/tags/blocks/slabs.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:blasted_iron_slab",
+    "oreganized:cut_blasted_iron_slab",
+    "oreganized:cut_cast_iron_slab",
+    "oreganized:cut_technical_netherite_slab",
+    "oreganized:lightened_iron_slab",
+    "oreganized:technical_netherite_slab"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/stairs.json
+++ b/src/main/resources/data/minecraft/tags/blocks/stairs.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:blasted_iron_stairs",
+    "oreganized:cut_blasted_iron_stairs",
+    "oreganized:cut_cast_iron_stairs",
+    "oreganized:cut_technical_netherite_stairs",
+    "oreganized:lightened_iron_stairs",
+    "oreganized:technical_netherite_stairs"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/slabs.json
+++ b/src/main/resources/data/minecraft/tags/items/slabs.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:blasted_iron_slab",
+    "oreganized:cut_blasted_iron_slab",
+    "oreganized:cut_cast_iron_slab",
+    "oreganized:cut_technical_netherite_slab",
+    "oreganized:lightened_iron_slab",
+    "oreganized:technical_netherite_slab"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/stairs.json
+++ b/src/main/resources/data/minecraft/tags/items/stairs.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "oreganized:blasted_iron_stairs",
+    "oreganized:cut_blasted_iron_stairs",
+    "oreganized:cut_cast_iron_stairs",
+    "oreganized:cut_technical_netherite_stairs",
+    "oreganized:lightened_iron_stairs",
+    "oreganized:technical_netherite_stairs"
+  ]
+}

--- a/src/main/resources/data/oreganized/recipes/black_crystal_glass.json
+++ b/src/main/resources/data/oreganized/recipes/black_crystal_glass.json
@@ -11,7 +11,7 @@
       "item": "minecraft:black_stained_glass"
     },
     "#": {
-      "item": "oreganized:lead_ingot"
+      "tag": "forge:ingots/lead"
     }
   },
   "result": {

--- a/src/main/resources/data/oreganized/recipes/blue_crystal_glass.json
+++ b/src/main/resources/data/oreganized/recipes/blue_crystal_glass.json
@@ -11,7 +11,7 @@
       "item": "minecraft:blue_stained_glass"
     },
     "#": {
-      "item": "oreganized:lead_ingot"
+      "tag": "forge:ingots/lead"
     }
   },
   "result": {

--- a/src/main/resources/data/oreganized/recipes/brown_crystal_glass.json
+++ b/src/main/resources/data/oreganized/recipes/brown_crystal_glass.json
@@ -11,7 +11,7 @@
       "item": "minecraft:brown_stained_glass"
     },
     "#": {
-      "item": "oreganized:lead_ingot"
+      "tag": "forge:ingots/lead"
     }
   },
   "result": {

--- a/src/main/resources/data/oreganized/recipes/crystal_glass.json
+++ b/src/main/resources/data/oreganized/recipes/crystal_glass.json
@@ -11,7 +11,7 @@
       "item": "minecraft:glass"
     },
     "#": {
-      "item": "oreganized:lead_ingot"
+      "tag": "forge:ingots/lead"
     }
   },
   "result": {

--- a/src/main/resources/data/oreganized/recipes/cyan_crystal_glass.json
+++ b/src/main/resources/data/oreganized/recipes/cyan_crystal_glass.json
@@ -11,7 +11,7 @@
       "item": "minecraft:cyan_stained_glass"
     },
     "#": {
-      "item": "oreganized:lead_ingot"
+      "tag": "forge:ingots/lead"
     }
   },
   "result": {

--- a/src/main/resources/data/oreganized/recipes/exposer.json
+++ b/src/main/resources/data/oreganized/recipes/exposer.json
@@ -7,13 +7,13 @@
   ],
   "key": {
     "x": {
-      "item": "minecraft:cobblestone"
+      "tag": "forge:cobblestone"
     },
     "r": {
-      "item": "minecraft:redstone"
+      "tag": "forge:dusts/redstone"
     },
     "s": {
-      "item": "oreganized:silver_ingot"
+      "tag": "forge:ingots/silver"
     }
   },
   "result": {

--- a/src/main/resources/data/oreganized/recipes/gray_crystal_glass.json
+++ b/src/main/resources/data/oreganized/recipes/gray_crystal_glass.json
@@ -11,7 +11,7 @@
       "item": "minecraft:gray_stained_glass"
     },
     "#": {
-      "item": "oreganized:lead_ingot"
+      "tag": "forge:ingots/lead"
     }
   },
   "result": {

--- a/src/main/resources/data/oreganized/recipes/green_crystal_glass.json
+++ b/src/main/resources/data/oreganized/recipes/green_crystal_glass.json
@@ -11,7 +11,7 @@
       "item": "minecraft:green_stained_glass"
     },
     "#": {
-      "item": "oreganized:lead_ingot"
+      "tag": "forge:ingots/lead"
     }
   },
   "result": {

--- a/src/main/resources/data/oreganized/recipes/lead_coating.json
+++ b/src/main/resources/data/oreganized/recipes/lead_coating.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shapeless",
   "ingredients": [
     {
-      "item": "oreganized:lead_ingot"
+      "tag": "forge:ingots/lead"
     },
     {
       "item": "oreganized:lightened_iron_block"

--- a/src/main/resources/data/oreganized/recipes/light_blue_crystal_glass.json
+++ b/src/main/resources/data/oreganized/recipes/light_blue_crystal_glass.json
@@ -11,7 +11,7 @@
       "item": "minecraft:light_blue_stained_glass"
     },
     "#": {
-      "item": "oreganized:lead_ingot"
+      "tag": "forge:ingots/lead"
     }
   },
   "result": {

--- a/src/main/resources/data/oreganized/recipes/light_gray_crystal_glass.json
+++ b/src/main/resources/data/oreganized/recipes/light_gray_crystal_glass.json
@@ -11,7 +11,7 @@
       "item": "minecraft:light_gray_stained_glass"
     },
     "#": {
-      "item": "oreganized:lead_ingot"
+      "tag": "forge:ingots/lead"
     }
   },
   "result": {

--- a/src/main/resources/data/oreganized/recipes/lightened_iron_block.json
+++ b/src/main/resources/data/oreganized/recipes/lightened_iron_block.json
@@ -6,7 +6,7 @@
   ],
   "key": {
     "x": {
-      "item": "minecraft:iron_ingot"
+      "tag": "forge:ingots/iron"
     }
   },
   "result": {

--- a/src/main/resources/data/oreganized/recipes/lime_crystal_glass.json
+++ b/src/main/resources/data/oreganized/recipes/lime_crystal_glass.json
@@ -11,7 +11,7 @@
       "item": "minecraft:lime_stained_glass"
     },
     "#": {
-      "item": "oreganized:lead_ingot"
+      "tag": "forge:ingots/lead"
     }
   },
   "result": {

--- a/src/main/resources/data/oreganized/recipes/magenta_crystal_glass.json
+++ b/src/main/resources/data/oreganized/recipes/magenta_crystal_glass.json
@@ -11,7 +11,7 @@
       "item": "minecraft:magenta_stained_glass"
     },
     "#": {
-      "item": "oreganized:lead_ingot"
+      "tag": "forge:ingots/lead"
     }
   },
   "result": {

--- a/src/main/resources/data/oreganized/recipes/netherite_ingot_from_netherite_nugget.json
+++ b/src/main/resources/data/oreganized/recipes/netherite_ingot_from_netherite_nugget.json
@@ -11,7 +11,7 @@
   {
     "x":
     {
-      "item": "oreganized:netherite_nugget"
+      "tag": "forge:nuggets/netherite"
     }
   },
   "result":

--- a/src/main/resources/data/oreganized/recipes/netherite_nugget.json
+++ b/src/main/resources/data/oreganized/recipes/netherite_nugget.json
@@ -3,7 +3,7 @@
   "group": "netherite_ingot",
   "ingredients": [
     {
-      "item": "minecraft:netherite_ingot"
+      "tag": "forge:ingots/netherite"
     }
   ],
   "result":

--- a/src/main/resources/data/oreganized/recipes/orange_crystal_glass.json
+++ b/src/main/resources/data/oreganized/recipes/orange_crystal_glass.json
@@ -11,7 +11,7 @@
       "item": "minecraft:orange_stained_glass"
     },
     "#": {
-      "item": "oreganized:lead_ingot"
+      "tag": "forge:ingots/lead"
     }
   },
   "result": {

--- a/src/main/resources/data/oreganized/recipes/pink_crystal_glass.json
+++ b/src/main/resources/data/oreganized/recipes/pink_crystal_glass.json
@@ -11,7 +11,7 @@
       "item": "minecraft:pink_stained_glass"
     },
     "#": {
-      "item": "oreganized:lead_ingot"
+      "tag": "forge:ingots/lead"
     }
   },
   "result": {

--- a/src/main/resources/data/oreganized/recipes/purple_crystal_glass.json
+++ b/src/main/resources/data/oreganized/recipes/purple_crystal_glass.json
@@ -11,7 +11,7 @@
       "item": "minecraft:purple_stained_glass"
     },
     "#": {
-      "item": "oreganized:lead_ingot"
+      "tag": "forge:ingots/lead"
     }
   },
   "result": {

--- a/src/main/resources/data/oreganized/recipes/red_crystal_glass.json
+++ b/src/main/resources/data/oreganized/recipes/red_crystal_glass.json
@@ -11,7 +11,7 @@
       "item": "minecraft:red_stained_glass"
     },
     "#": {
-      "item": "oreganized:lead_ingot"
+      "tag": "forge:ingots/lead"
     }
   },
   "result": {

--- a/src/main/resources/data/oreganized/recipes/shrapnel_tnt.json
+++ b/src/main/resources/data/oreganized/recipes/shrapnel_tnt.json
@@ -7,7 +7,8 @@
   ],
   "key": {
     "x": {
-      "item": "oreganized:lead_ingot"
+      "tag": "forge:ingots/lead"
+
     },
     "#": {
       "item": "minecraft:tnt"

--- a/src/main/resources/data/oreganized/recipes/silver_mirror.json
+++ b/src/main/resources/data/oreganized/recipes/silver_mirror.json
@@ -7,13 +7,13 @@
   ],
   "key": {
     "x": {
-      "item": "minecraft:gold_ingot"
+      "tag": "forge:ingots/gold"
     },
     "y": {
       "item": "minecraft:glass_pane"
     },
     "#": {
-      "item": "oreganized:silver_ingot"
+      "tag": "forge:ingots/silver"
     }
   },
   "result": {

--- a/src/main/resources/data/oreganized/recipes/silver_tinted_diamond_boots.json
+++ b/src/main/resources/data/oreganized/recipes/silver_tinted_diamond_boots.json
@@ -4,7 +4,7 @@
     "item": "minecraft:diamond_boots"
   },
   "addition": {
-    "item": "oreganized:silver_ingot"
+    "tag": "forge:ingots/silver"
   },
   "result": {
     "item": "oreganized:silver_tinted_diamond_boots"

--- a/src/main/resources/data/oreganized/recipes/silver_tinted_diamond_chestplate.json
+++ b/src/main/resources/data/oreganized/recipes/silver_tinted_diamond_chestplate.json
@@ -4,7 +4,7 @@
     "item": "minecraft:diamond_chestplate"
   },
   "addition": {
-    "item": "oreganized:silver_ingot"
+    "tag": "forge:ingots/silver"
   },
   "result": {
     "item": "oreganized:silver_tinted_diamond_chestplate"

--- a/src/main/resources/data/oreganized/recipes/silver_tinted_diamond_helmet.json
+++ b/src/main/resources/data/oreganized/recipes/silver_tinted_diamond_helmet.json
@@ -4,7 +4,7 @@
     "item": "minecraft:diamond_helmet"
   },
   "addition": {
-    "item": "oreganized:silver_ingot"
+    "tag": "forge:ingots/silver"
   },
   "result": {
     "item": "oreganized:silver_tinted_diamond_helmet"

--- a/src/main/resources/data/oreganized/recipes/silver_tinted_diamond_leggings.json
+++ b/src/main/resources/data/oreganized/recipes/silver_tinted_diamond_leggings.json
@@ -4,7 +4,7 @@
     "item": "minecraft:diamond_leggings"
   },
   "addition": {
-    "item": "oreganized:silver_ingot"
+    "tag": "forge:ingots/silver"
   },
   "result": {
     "item": "oreganized:silver_tinted_diamond_leggings"

--- a/src/main/resources/data/oreganized/recipes/silver_tinted_diamond_sword.json
+++ b/src/main/resources/data/oreganized/recipes/silver_tinted_diamond_sword.json
@@ -4,7 +4,7 @@
     "item": "minecraft:diamond_sword"
   },
   "addition": {
-    "item": "oreganized:silver_ingot"
+    "tag": "forge:ingots/silver"
   },
   "result": {
     "item": "oreganized:silver_tinted_diamond_sword"

--- a/src/main/resources/data/oreganized/recipes/silver_tinted_golden_boots.json
+++ b/src/main/resources/data/oreganized/recipes/silver_tinted_golden_boots.json
@@ -4,7 +4,7 @@
     "item": "minecraft:golden_boots"
   },
   "addition": {
-    "item": "oreganized:silver_ingot"
+    "tag": "forge:ingots/silver"
   },
   "result": {
     "item": "oreganized:silver_tinted_golden_boots"

--- a/src/main/resources/data/oreganized/recipes/silver_tinted_golden_chestplate.json
+++ b/src/main/resources/data/oreganized/recipes/silver_tinted_golden_chestplate.json
@@ -4,7 +4,7 @@
     "item": "minecraft:golden_chestplate"
   },
   "addition": {
-    "item": "oreganized:silver_ingot"
+    "tag": "forge:ingots/silver"
   },
   "result": {
     "item": "oreganized:silver_tinted_golden_chestplate"

--- a/src/main/resources/data/oreganized/recipes/silver_tinted_golden_helmet.json
+++ b/src/main/resources/data/oreganized/recipes/silver_tinted_golden_helmet.json
@@ -4,7 +4,7 @@
     "item": "minecraft:golden_helmet"
   },
   "addition": {
-    "item": "oreganized:silver_ingot"
+    "tag": "forge:ingots/silver"
   },
   "result": {
     "item": "oreganized:silver_tinted_golden_helmet"

--- a/src/main/resources/data/oreganized/recipes/silver_tinted_golden_leggings.json
+++ b/src/main/resources/data/oreganized/recipes/silver_tinted_golden_leggings.json
@@ -4,7 +4,7 @@
     "item": "minecraft:golden_leggings"
   },
   "addition": {
-    "item": "oreganized:silver_ingot"
+    "tag": "forge:ingots/silver"
   },
   "result": {
     "item": "oreganized:silver_tinted_golden_leggings"

--- a/src/main/resources/data/oreganized/recipes/silver_tinted_golden_sword.json
+++ b/src/main/resources/data/oreganized/recipes/silver_tinted_golden_sword.json
@@ -4,7 +4,7 @@
     "item": "minecraft:golden_sword"
   },
   "addition": {
-    "item": "oreganized:silver_ingot"
+    "tag": "forge:ingots/silver"
   },
   "result": {
     "item": "oreganized:silver_tinted_golden_sword"

--- a/src/main/resources/data/oreganized/recipes/silver_tinted_netherite_boots.json
+++ b/src/main/resources/data/oreganized/recipes/silver_tinted_netherite_boots.json
@@ -4,7 +4,7 @@
     "item": "minecraft:netherite_boots"
   },
   "addition": {
-    "item": "oreganized:silver_ingot"
+    "tag": "forge:ingots/silver"
   },
   "result": {
     "item": "oreganized:silver_tinted_netherite_boots"

--- a/src/main/resources/data/oreganized/recipes/silver_tinted_netherite_boots_from_upgrade.json
+++ b/src/main/resources/data/oreganized/recipes/silver_tinted_netherite_boots_from_upgrade.json
@@ -4,7 +4,7 @@
     "item": "oreganized:silver_tinted_diamond_boots"
   },
   "addition": {
-    "item": "minecraft:netherite_ingot"
+    "tag": "forge:ingots/netherite"
   },
   "result": {
     "item": "oreganized:silver_tinted_netherite_boots"

--- a/src/main/resources/data/oreganized/recipes/silver_tinted_netherite_chestplate.json
+++ b/src/main/resources/data/oreganized/recipes/silver_tinted_netherite_chestplate.json
@@ -4,7 +4,7 @@
     "item": "minecraft:netherite_chestplate"
   },
   "addition": {
-    "item": "oreganized:silver_ingot"
+    "tag": "forge:ingots/silver"
   },
   "result": {
     "item": "oreganized:silver_tinted_netherite_chestplate"

--- a/src/main/resources/data/oreganized/recipes/silver_tinted_netherite_chestplate_from_upgrade.json
+++ b/src/main/resources/data/oreganized/recipes/silver_tinted_netherite_chestplate_from_upgrade.json
@@ -4,7 +4,7 @@
     "item": "oreganized:silver_tinted_diamond_chestplate"
   },
   "addition": {
-    "item": "minecraft:netherite_ingot"
+    "tag": "forge:ingots/netherite"
   },
   "result": {
     "item": "oreganized:silver_tinted_netherite_chestplate"

--- a/src/main/resources/data/oreganized/recipes/silver_tinted_netherite_helmet.json
+++ b/src/main/resources/data/oreganized/recipes/silver_tinted_netherite_helmet.json
@@ -4,7 +4,7 @@
     "item": "minecraft:netherite_helmet"
   },
   "addition": {
-    "item": "oreganized:silver_ingot"
+    "tag": "forge:ingots/silver"
   },
   "result": {
     "item": "oreganized:silver_tinted_netherite_helmet"

--- a/src/main/resources/data/oreganized/recipes/silver_tinted_netherite_helmet_from_upgrade.json
+++ b/src/main/resources/data/oreganized/recipes/silver_tinted_netherite_helmet_from_upgrade.json
@@ -4,7 +4,7 @@
     "item": "oreganized:silver_tinted_diamond_helmet"
   },
   "addition": {
-    "item": "minecraft:netherite_ingot"
+    "tag": "forge:ingots/netherite"
   },
   "result": {
     "item": "oreganized:silver_tinted_netherite_helmet"

--- a/src/main/resources/data/oreganized/recipes/silver_tinted_netherite_leggings.json
+++ b/src/main/resources/data/oreganized/recipes/silver_tinted_netherite_leggings.json
@@ -4,7 +4,7 @@
     "item": "minecraft:netherite_leggings"
   },
   "addition": {
-    "item": "oreganized:silver_ingot"
+    "tag": "forge:ingots/silver"
   },
   "result": {
     "item": "oreganized:silver_tinted_netherite_leggings"

--- a/src/main/resources/data/oreganized/recipes/silver_tinted_netherite_leggings_from_upgrade.json
+++ b/src/main/resources/data/oreganized/recipes/silver_tinted_netherite_leggings_from_upgrade.json
@@ -4,7 +4,7 @@
     "item": "oreganized:silver_tinted_diamond_leggings"
   },
   "addition": {
-    "item": "minecraft:netherite_ingot"
+    "tag": "forge:ingots/netherite"
   },
   "result": {
     "item": "oreganized:silver_tinted_netherite_leggings"

--- a/src/main/resources/data/oreganized/recipes/silver_tinted_netherite_sword.json
+++ b/src/main/resources/data/oreganized/recipes/silver_tinted_netherite_sword.json
@@ -4,7 +4,7 @@
     "item": "minecraft:netherite_sword"
   },
   "addition": {
-    "item": "oreganized:silver_ingot"
+    "tag": "forge:ingots/silver"
   },
   "result": {
     "item": "oreganized:silver_tinted_netherite_sword"

--- a/src/main/resources/data/oreganized/recipes/silver_tinted_netherite_sword_from_upgrade.json
+++ b/src/main/resources/data/oreganized/recipes/silver_tinted_netherite_sword_from_upgrade.json
@@ -4,7 +4,7 @@
     "item": "oreganized:silver_tinted_diamond_sword"
   },
   "addition": {
-    "item": "minecraft:netherite_ingot"
+    "tag": "forge:ingots/netherite"
   },
   "result": {
     "item": "oreganized:silver_tinted_netherite_sword"

--- a/src/main/resources/data/oreganized/recipes/technical_netherite_block.json
+++ b/src/main/resources/data/oreganized/recipes/technical_netherite_block.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "x": {
-      "item": "oreganized:netherite_nugget"
+      "tag": "forge:nuggets/netherite"
     },
     "#": {
       "item": "oreganized:cast_iron_block"

--- a/src/main/resources/data/oreganized/recipes/white_crystal_glass.json
+++ b/src/main/resources/data/oreganized/recipes/white_crystal_glass.json
@@ -11,7 +11,7 @@
       "item": "minecraft:white_stained_glass"
     },
     "#": {
-      "item": "oreganized:lead_ingot"
+      "tag": "forge:ingots/lead"
     }
   },
   "result": {

--- a/src/main/resources/data/oreganized/recipes/yellow_crystal_glass.json
+++ b/src/main/resources/data/oreganized/recipes/yellow_crystal_glass.json
@@ -11,7 +11,7 @@
       "item": "minecraft:yellow_stained_glass"
     },
     "#": {
-      "item": "oreganized:lead_ingot"
+      "tag": "forge:ingots/lead"
     }
   },
   "result": {


### PR DESCRIPTION
Basically, I added a bunch of tags to everything in order to be inline with forge standards and to be semi compatible with more mods. In addition, I switched recipes over from using blocks to tags whenever possible. I know I already did a PR with that, but I missed a few, and also wanted to revise a couple of those recipes again (*cough* crystal glass *cough*).
Some highlights:
 - every crystal glass and glass pane is in its proper color of glass (ie red crystal glass is in forge:glass/red)
 - crystal glass can be made using lead from any properly tagged mod, but still must be made with minecraft's glass
 - you can made silver coated gear using any mod's silver
 - all the stairs and slabs now have proper minecraft tags
 - technical netherite can be made with any mod's netherite nuggets
 - lead coating can be made with any mod's lead
 - the exposer can be crafted with any mod's cobblestone (some mods, like Create, add cobbled versions of vanilla stone types, such as cobbled granite), and with any mod's silver

fair warning, this was a lot of jsons, and its possible I missed a comma or two. if the game crashes on startup, that might be why

lemme know if you have any questions or need me