### PR TITLE
Fix configured and placed features + Stunned effect fix

### DIFF
--- a/src/main/java/me/gleep/oreganized/Oreganized.java
+++ b/src/main/java/me/gleep/oreganized/Oreganized.java
@@ -8,7 +8,6 @@ import me.gleep.oreganized.util.RegistryHandler;
 import me.gleep.oreganized.util.SimpleNetwork;
 import me.gleep.oreganized.events.*;
 import me.gleep.oreganized.world.gen.OreganizedConfiguredFeatures;
-import me.gleep.oreganized.world.gen.OreganizedPlacedFeatures;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.RenderType;
@@ -37,11 +36,11 @@ public class Oreganized {
 
     public Oreganized() {
         IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
+        RegistryHandler.init();
         bus.addListener(this::setup);
         bus.addListener(this::doClientStuff);
         bus.addListener(this::registerRenderers);
 
-        RegistryHandler.init();
         MinecraftForge.EVENT_BUS.register( new CapabilityHandler() );
         //MinecraftForge.EVENT_BUS.register( new StunnedOverlayRenderer() );
     }
@@ -49,8 +48,7 @@ public class Oreganized {
     private void setup(final FMLCommonSetupEvent event) {
 
         event.enqueueWork(() -> {
-            OreganizedConfiguredFeatures.registerConfiguredFeatures();
-            OreganizedPlacedFeatures.registerPlacedFeatures();
+            OreganizedConfiguredFeatures.init();
             SimpleNetwork.register();
         });
 

--- a/src/main/java/me/gleep/oreganized/effect/StunnedEffect.java
+++ b/src/main/java/me/gleep/oreganized/effect/StunnedEffect.java
@@ -1,0 +1,50 @@
+package me.gleep.oreganized.effect;
+
+import me.gleep.oreganized.Oreganized;
+import me.gleep.oreganized.potion.ModPotions;
+import net.minecraft.client.player.Input;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.MobEffectCategory;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.MovementInputUpdateEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * @author SameButDifferent
+ */
+@Mod.EventBusSubscriber(modid = Oreganized.MOD_ID, value = Dist.CLIENT)
+public class StunnedEffect extends MobEffect {
+    public StunnedEffect(MobEffectCategory category, int color) {
+        super(category, color);
+    }
+
+    @Override
+    public void applyEffectTick(LivingEntity entity, int amplifier) {
+        if (entity.isOnGround() || entity.isInWater()) {
+            entity.setDeltaMovement(Vec3.ZERO);
+        }
+    }
+
+    @Override
+    public boolean isDurationEffectTick(int pDuration, int pAmplifier) {
+        return true;
+    }
+
+    @SubscribeEvent
+    public static void onInputUpdate(MovementInputUpdateEvent event) {
+        Input input = event.getInput();
+        if (event.getPlayer().hasEffect(ModPotions.STUNNED)) {
+            input.up = false;
+            input.down = false;
+            input.left = false;
+            input.right = false;
+            input.forwardImpulse = 0;
+            input.leftImpulse = 0;
+            input.jumping = false;
+            input.shiftKeyDown = false;
+        }
+    }
+}

--- a/src/main/java/me/gleep/oreganized/events/ModEvents.java
+++ b/src/main/java/me/gleep/oreganized/events/ModEvents.java
@@ -19,6 +19,7 @@ import me.gleep.oreganized.potion.ModPotions;
 import me.gleep.oreganized.tools.STSBase;
 import me.gleep.oreganized.util.RegistryHandler;
 import me.gleep.oreganized.util.messages.UpdateClientEngravedBlocks;
+import me.gleep.oreganized.world.gen.OreganizedPlacedFeatures;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementList;
 import net.minecraft.advancements.CriteriaTriggers;
@@ -52,15 +53,18 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.piston.PistonStructureResolver;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.GenerationStep;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.EntityViewRenderEvent;
 import net.minecraftforge.client.event.MovementInputUpdateEvent;
+import net.minecraftforge.common.world.BiomeGenerationSettingsBuilder;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.living.LivingEntityUseItemEvent;
@@ -68,6 +72,7 @@ import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.event.world.BiomeLoadingEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.PistonEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -467,5 +472,20 @@ public class ModEvents {
         IEngravedBlocks cap = level.getCapability( CapabilityEngravedBlocks.ENGRAVED_BLOCKS_CAPABILITY ).orElse( null );
         CHANNEL.send( PacketDistributor.PLAYER.with( () -> player ) ,
                 new UpdateClientEngravedBlocks( cap.getEngravedBlocks() , cap.getEngravedFaces() , cap.getEngravedColors() ) );
+    }
+
+    @SubscribeEvent
+    public static void registerBiomeModification(BiomeLoadingEvent event) {
+        BiomeGenerationSettingsBuilder generation = event.getGeneration();
+        if (event.getCategory().equals(Biome.BiomeCategory.SAVANNA)) {
+            generation.getFeatures(GenerationStep.Decoration.UNDERGROUND_ORES).add(OreganizedPlacedFeatures.ORE_LEAD_SAVANNA);
+        } else {
+            generation.getFeatures(GenerationStep.Decoration.UNDERGROUND_ORES).add(OreganizedPlacedFeatures.ORE_SILVER_DEEPSLATE_UP);
+            generation.getFeatures(GenerationStep.Decoration.UNDERGROUND_ORES).add(OreganizedPlacedFeatures.ORE_SILVER_DEEPSLATE_DOWN);
+            generation.getFeatures(GenerationStep.Decoration.UNDERGROUND_ORES).add(OreganizedPlacedFeatures.ORE_SILVER_UP);
+            generation.getFeatures(GenerationStep.Decoration.UNDERGROUND_ORES).add(OreganizedPlacedFeatures.ORE_SILVER_DOWN);
+            generation.getFeatures(GenerationStep.Decoration.UNDERGROUND_ORES).add(OreganizedPlacedFeatures.ORE_LEAD_DEEPSLATE_UP);
+            generation.getFeatures(GenerationStep.Decoration.UNDERGROUND_ORES).add(OreganizedPlacedFeatures.ORE_LEAD_DEEPSLATE_DOWN);
+        }
     }
 }

--- a/src/main/java/me/gleep/oreganized/potion/ModPotions.java
+++ b/src/main/java/me/gleep/oreganized/potion/ModPotions.java
@@ -3,6 +3,7 @@ package me.gleep.oreganized.potion;
 import me.gleep.oreganized.Oreganized;
 import me.gleep.oreganized.capabilities.stunning.CapabilityStunning;
 import me.gleep.oreganized.capabilities.stunning.IStunning;
+import me.gleep.oreganized.effect.StunnedEffect;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
 import net.minecraft.world.effect.MobEffectInstance;
@@ -24,24 +25,7 @@ import static me.gleep.oreganized.util.RegistryHandler.LEAD_INGOTS_ITEMTAG;
 @Mod.EventBusSubscriber(modid = Oreganized.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
 public class ModPotions{
 
-    public static MobEffect STUNNED = new MobEffect( MobEffectCategory.HARMFUL , 0x3B3B63 ){
-        @Override
-        public boolean isDurationEffectTick( int pDuration , int pAmplifier ){
-            int k = 300;
-            return pDuration % k == 0;
-        }
-
-        @Override
-        public void applyEffectTick( LivingEntity pLivingEntity , int pAmplifier ){
-            Level level = pLivingEntity.level;
-            IStunning stunningCap = pLivingEntity.getCapability(CapabilityStunning.STUNNING_CAPABILITY, null ).orElse(null);
-            if(stunningCap != null){
-                stunningCap.setPreviousPos( pLivingEntity.blockPosition() );
-                stunningCap.setRemainingStunTime((int) Math.floor((Math.max( 5, Math.floor(Math.random() * 12) ) * 20) * ((3f/4f)*(pAmplifier+1))));
-            }
-            super.applyEffectTick( pLivingEntity, pAmplifier );
-        }
-    };
+    public static MobEffect STUNNED = new StunnedEffect(MobEffectCategory.HARMFUL, 0x3B3B63);
 
     public static Potion STUNNING_POTION = new Potion( "stunning" , new MobEffectInstance( STUNNED , 40 * 20 ) );
     public static Potion STUNNING_POTION_LONG = new Potion( "stunning" , new MobEffectInstance( STUNNED , 80 * 20 ) );

--- a/src/main/java/me/gleep/oreganized/world/gen/OreganizedConfiguredFeatures.java
+++ b/src/main/java/me/gleep/oreganized/world/gen/OreganizedConfiguredFeatures.java
@@ -1,41 +1,33 @@
 package me.gleep.oreganized.world.gen;
 
+import com.google.common.collect.ImmutableList;
 import me.gleep.oreganized.Oreganized;
 import me.gleep.oreganized.util.RegistryHandler;
-import net.minecraft.core.Registry;
+import net.minecraft.core.Holder;
 import net.minecraft.data.BuiltinRegistries;
 import net.minecraft.data.worldgen.features.OreFeatures;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraft.world.level.levelgen.feature.Feature;
+import net.minecraft.world.level.levelgen.feature.configurations.FeatureConfiguration;
 import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguration;
 
-import java.util.List;
-
 public class OreganizedConfiguredFeatures {
+    public static final ImmutableList<OreConfiguration.TargetBlockState> ORE_SILVER_TARGET_LIST = ImmutableList.of(OreConfiguration.target(OreFeatures.STONE_ORE_REPLACEABLES, RegistryHandler.SILVER_ORE.get().defaultBlockState()),
+            OreConfiguration.target(OreFeatures.DEEPSLATE_ORE_REPLACEABLES, RegistryHandler.DEEPSLATE_SILVER_ORE.get().defaultBlockState()));
+    public static final ImmutableList<OreConfiguration.TargetBlockState> ORE_LEAD_TARGET_LIST = ImmutableList.of(OreConfiguration.target(OreFeatures.STONE_ORE_REPLACEABLES, RegistryHandler.LEAD_ORE.get().defaultBlockState()),
+            OreConfiguration.target(OreFeatures.DEEPSLATE_ORE_REPLACEABLES, RegistryHandler.DEEPSLATE_LEAD_ORE.get().defaultBlockState()));
 
-    public static List <OreConfiguration.TargetBlockState> ORE_SILVER_TARGET_LIST;
-    public static List <OreConfiguration.TargetBlockState> ORE_LEAD_TARGET_LIST;
+    public static final Holder<ConfiguredFeature<OreConfiguration, ?>> ORE_SILVER = register("silver_ore", Feature.ORE, new OreConfiguration(ORE_SILVER_TARGET_LIST, 14));
+    public static final Holder<ConfiguredFeature<OreConfiguration, ?>> ORE_SILVER_DEEP_UNDERGROUND = register("silver_ore_underground", Feature.ORE, new OreConfiguration(ORE_SILVER_TARGET_LIST, 9));
+    public static final Holder<ConfiguredFeature<OreConfiguration, ?>> ORE_LEAD = register("lead_ore", Feature.ORE, new OreConfiguration(ORE_LEAD_TARGET_LIST, 13));
+    public static final Holder<ConfiguredFeature<OreConfiguration, ?>> ORE_LEAD_DEEP_UNDERGROUND = register("lead_ore_underground", Feature.ORE, new OreConfiguration(ORE_LEAD_TARGET_LIST, 8));
 
-    public static ConfiguredFeature <?, ?> ORE_SILVER;
-    public static ConfiguredFeature <?, ?> ORE_SILVER_DEEP_UNDERGROUND;
-    public static ConfiguredFeature <?, ?> ORE_LEAD;
-    public static ConfiguredFeature <?, ?> ORE_LEAD_DEEP_UNDERGROUND;
+    private static <FC extends FeatureConfiguration, F extends Feature<FC>> Holder<ConfiguredFeature<FC, ?>> register(String key, F feature, FC config) {
+        return BuiltinRegistries.registerExact(BuiltinRegistries.CONFIGURED_FEATURE, new ResourceLocation(Oreganized.MOD_ID, key).toString(), new ConfiguredFeature<>(feature, config));
+    }
 
-    public static void registerConfiguredFeatures() {
-        ORE_SILVER_TARGET_LIST = List.of( OreConfiguration.target( OreFeatures.STONE_ORE_REPLACEABLES , RegistryHandler.SILVER_ORE.get().defaultBlockState() ) ,
-                OreConfiguration.target( OreFeatures.DEEPSLATE_ORE_REPLACEABLES , RegistryHandler.DEEPSLATE_SILVER_ORE.get().defaultBlockState() ) );
-        ORE_LEAD_TARGET_LIST = List.of( OreConfiguration.target( OreFeatures.STONE_ORE_REPLACEABLES , RegistryHandler.LEAD_ORE.get().defaultBlockState() ) ,
-                OreConfiguration.target( OreFeatures.DEEPSLATE_ORE_REPLACEABLES , RegistryHandler.DEEPSLATE_LEAD_ORE.get().defaultBlockState() ) );
+    public static void init() {
 
-        ORE_SILVER_DEEP_UNDERGROUND = new ConfiguredFeature<>(Feature.ORE, new OreConfiguration( ORE_SILVER_TARGET_LIST , 14 ) );
-        ORE_SILVER = new ConfiguredFeature<>(Feature.ORE, new OreConfiguration( ORE_SILVER_TARGET_LIST , 9 ) );
-        ORE_LEAD_DEEP_UNDERGROUND = new ConfiguredFeature<>(Feature.ORE, new OreConfiguration( ORE_LEAD_TARGET_LIST , 13 ) );
-        ORE_LEAD = new ConfiguredFeature<>(Feature.ORE, new OreConfiguration( ORE_LEAD_TARGET_LIST , 8 ) );
-
-        Registry.register( BuiltinRegistries.CONFIGURED_FEATURE , new ResourceLocation( Oreganized.MOD_ID , "silver_ore" ) , ORE_SILVER );
-        Registry.register( BuiltinRegistries.CONFIGURED_FEATURE , new ResourceLocation( Oreganized.MOD_ID , "silver_ore_underground" ) , ORE_SILVER_DEEP_UNDERGROUND );
-        Registry.register( BuiltinRegistries.CONFIGURED_FEATURE , new ResourceLocation( Oreganized.MOD_ID , "lead_ore" ) , ORE_LEAD );
-        Registry.register( BuiltinRegistries.CONFIGURED_FEATURE , new ResourceLocation( Oreganized.MOD_ID , "lead_ore_underground" ) , ORE_LEAD_DEEP_UNDERGROUND );
     }
 }

--- a/src/main/java/me/gleep/oreganized/world/gen/OreganizedPlacedFeatures.java
+++ b/src/main/java/me/gleep/oreganized/world/gen/OreganizedPlacedFeatures.java
@@ -2,129 +2,31 @@ package me.gleep.oreganized.world.gen;
 
 import me.gleep.oreganized.Oreganized;
 import net.minecraft.core.Holder;
-import net.minecraft.core.Registry;
-import net.minecraft.data.BuiltinRegistries;
+import net.minecraft.data.worldgen.placement.PlacementUtils;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.level.biome.Biome;
-import net.minecraft.world.level.levelgen.GenerationStep;
 import net.minecraft.world.level.levelgen.VerticalAnchor;
+import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraft.world.level.levelgen.placement.*;
-import net.minecraftforge.common.world.BiomeGenerationSettingsBuilder;
-import net.minecraftforge.event.world.BiomeLoadingEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static me.gleep.oreganized.world.gen.OreganizedConfiguredFeatures.*;
 
-
-@Mod.EventBusSubscriber
 public class OreganizedPlacedFeatures{
-    public static PlacedFeature ORE_SILVER_DEEPSLATE_UP;
-    public static PlacedFeature ORE_SILVER_DEEPSLATE_DOWN;
-    public static PlacedFeature ORE_SILVER_UP;
-    public static PlacedFeature ORE_SILVER_DOWN;
-    public static PlacedFeature ORE_LEAD_DEEPSLATE_UP;
-    public static PlacedFeature ORE_LEAD_DEEPSLATE_DOWN;
-    public static PlacedFeature ORE_LEAD_SAVANNA;
+    public static Holder<PlacedFeature> ORE_SILVER_DEEPSLATE_UP = register("silver_ore_deepslate_up", ORE_SILVER_DEEP_UNDERGROUND, orePlacement(1, HeightRangePlacement.uniform(VerticalAnchor.absolute(-5), VerticalAnchor.absolute(5))));
+    public static Holder<PlacedFeature> ORE_SILVER_DEEPSLATE_DOWN = register("silver_ore_deepslate_down", ORE_SILVER_DEEP_UNDERGROUND, orePlacement(2, HeightRangePlacement.uniform(VerticalAnchor.absolute(-15), VerticalAnchor.absolute(-5)))); 
+    public static Holder<PlacedFeature> ORE_SILVER_UP = register("silver_ore_up", ORE_SILVER, orePlacement(1, HeightRangePlacement.uniform(VerticalAnchor.absolute(160), VerticalAnchor.absolute(180))));
+    public static Holder<PlacedFeature> ORE_SILVER_DOWN = register("silver_ore_down", ORE_SILVER, orePlacement(1, HeightRangePlacement.uniform(VerticalAnchor.absolute(140), VerticalAnchor.absolute(160))));
+    public static Holder<PlacedFeature> ORE_LEAD_DEEPSLATE_UP = register("lead_ore_deepslate_up", ORE_LEAD_DEEP_UNDERGROUND, orePlacement(1, HeightRangePlacement.triangle(VerticalAnchor.absolute(-33), VerticalAnchor.absolute(-20))));
+    public static Holder<PlacedFeature> ORE_LEAD_DEEPSLATE_DOWN = register("lead_ore_deepslate_down", ORE_LEAD_DEEP_UNDERGROUND, orePlacement(2, HeightRangePlacement.triangle(VerticalAnchor.absolute(-40), VerticalAnchor.absolute(-33))));
+    public static Holder<PlacedFeature> ORE_LEAD_SAVANNA = register("lead_ore_savanna", ORE_LEAD, orePlacement(13, HeightRangePlacement.uniform(VerticalAnchor.absolute(50), VerticalAnchor.absolute(80))));
 
-    private static final ArrayList <PlacedFeature> overwworldOres = new ArrayList <>();
-    //private static final ArrayList<ConfiguredFeature<?, ?>> netherOres = new ArrayList<ConfiguredFeature<?, ?>>();
-    //private static final ArrayList<ConfiguredFeature<?, ?>> endOres = new ArrayList<ConfiguredFeature<?, ?>>();
-
-    public static void registerPlacedFeatures(){
-        //BASE_STONE_OVERWORLD is for generating in stone, granite, diorite, and andesite
-        //NETHERRACK is for generating in netherrack
-        //BASE_STONE_NETHER is for generating in netherrack, basalt and blackstone
-
-        //Overworld Ore Register
-        /*overworldOres.add(register("silver_ore", Feature.ORE.configured(new OreConfiguration(
-                ORE_SILVER_TARGET_LIST, RegistryHandler.SILVER_ORE.get().defaultBlockState(), 3)) //Vein Size
-                .range(FeatureDecorator.RANGE.configured(new RangeDecoratorConfiguration(UniformHeight.of(VerticalAnchor.aboveBottom(30), VerticalAnchor.absolute(50)))).config())
-                .squared()
-                .rarity(4))
-        );*/
-
-        /*overworldOres.add(register("lead_ore", Feature.ORE.configured(new OreConfiguration(
-                OreConfiguration.Predicates.NATURAL_STONE, RegistryHandler.LEAD_ORE.get().defaultBlockState(), 16)) //Vein Size
-                .range(FeatureDecorator.RANGE.configured(new RangeDecoratorConfiguration(UniformHeight.of(VerticalAnchor.aboveBottom(30), VerticalAnchor.absolute(50)))).config())
-                .squared()
-                .rarity(1))
-        );
-
-        //Nether Ore Register
-        /*netherOres.add(register("flame_crystal_ore", Feature.ORE.withConfiguration(new OreFeatureConfig(
-                OreFeatureConfig.FillerBlockType.NETHERRACK, RegistryHandlerBlocks.FLAME_CRYSTAL_ORE.get().getDefaultState(), 4))
-                .range(48).square()
-                .func_242731_b(64)));*/
-
-        //The End Ore Register
-        /*endOres.add(register("air_block", Feature.ORE.withConfiguration(new OreFeatureConfig(
-                new BlockMatchRuleTest(Blocks.END_STONE), RegistryHandlerBlocks.AIR_CRYSTAL_BLOCK.get().getDefaultState(), 4)) //Vein Size
-                .range(128).square() //Spawn height start
-                .func_242731_b(64))); //Chunk spawn frequency*/
-        ORE_SILVER_DEEPSLATE_UP = new PlacedFeature(Holder.direct(ORE_SILVER_DEEP_UNDERGROUND), List.of( CountPlacement.of( 1 ) , InSquarePlacement.spread() ,
-                HeightRangePlacement.uniform( VerticalAnchor.absolute( -5 ) , VerticalAnchor.absolute( 5 ) ) ,
-                BiomeFilter.biome() ) );
-
-        ORE_SILVER_DEEPSLATE_DOWN = new PlacedFeature(Holder.direct(ORE_SILVER_DEEP_UNDERGROUND),  List.of( CountPlacement.of( 2 ) , InSquarePlacement.spread() ,
-                HeightRangePlacement.uniform( VerticalAnchor.absolute( -15 ) , VerticalAnchor.absolute( -5 ) ) ,
-                BiomeFilter.biome() ) );
-
-        ORE_SILVER_UP = new PlacedFeature(Holder.direct(ORE_SILVER), List.of( CountPlacement.of( 1 ) , InSquarePlacement.spread() ,
-                HeightRangePlacement.uniform( VerticalAnchor.absolute( 160 ) , VerticalAnchor.absolute( 180 ) ) ,
-                BiomeFilter.biome() ) );
-
-        ORE_SILVER_DOWN = new PlacedFeature(Holder.direct(ORE_SILVER), List.of( CountPlacement.of( 1 ) , InSquarePlacement.spread() ,
-                HeightRangePlacement.uniform( VerticalAnchor.absolute( 140 ) , VerticalAnchor.absolute( 160 ) ) ,
-                BiomeFilter.biome() ) );
-
-        ORE_LEAD_DEEPSLATE_UP = new PlacedFeature(Holder.direct(ORE_LEAD_DEEP_UNDERGROUND), List.of( CountPlacement.of( 1 ) , InSquarePlacement.spread() ,
-                HeightRangePlacement.triangle( VerticalAnchor.absolute( -33 ) , VerticalAnchor.absolute( -20 ) ) ,
-                BiomeFilter.biome() ) );
-
-        ORE_LEAD_DEEPSLATE_DOWN = new PlacedFeature(Holder.direct(ORE_LEAD_DEEP_UNDERGROUND), List.of( CountPlacement.of( 2 ) , InSquarePlacement.spread() ,
-                HeightRangePlacement.triangle( VerticalAnchor.absolute( -40 ) , VerticalAnchor.absolute( -33 ) ) ,
-                BiomeFilter.biome() ) );
-
-        ORE_LEAD_SAVANNA = new PlacedFeature(Holder.direct(ORE_LEAD), List.of( CountPlacement.of( 13 ) , InSquarePlacement.spread() ,
-                HeightRangePlacement.uniform( VerticalAnchor.absolute( 50 ) , VerticalAnchor.absolute( 80 ) ) ,
-                BiomeFilter.biome() ) );
-
-        Registry.register( BuiltinRegistries.PLACED_FEATURE , new ResourceLocation( Oreganized.MOD_ID , "silver_ore_deepslate_up" ) , ORE_SILVER_DEEPSLATE_UP );
-        Registry.register( BuiltinRegistries.PLACED_FEATURE , new ResourceLocation( Oreganized.MOD_ID , "silver_ore_deepslate_down" ) , ORE_SILVER_DEEPSLATE_DOWN );
-        Registry.register( BuiltinRegistries.PLACED_FEATURE , new ResourceLocation( Oreganized.MOD_ID , "silver_ore_up" ) , ORE_SILVER_UP );
-        Registry.register( BuiltinRegistries.PLACED_FEATURE , new ResourceLocation( Oreganized.MOD_ID , "silver_ore_down" ) , ORE_SILVER_DOWN );
-        Registry.register( BuiltinRegistries.PLACED_FEATURE , new ResourceLocation( Oreganized.MOD_ID , "lead_ore_deepslate_up" ) , ORE_LEAD_DEEPSLATE_UP );
-        Registry.register( BuiltinRegistries.PLACED_FEATURE , new ResourceLocation( Oreganized.MOD_ID , "lead_ore_deepslate_down" ) , ORE_LEAD_DEEPSLATE_DOWN );
-        Registry.register( BuiltinRegistries.PLACED_FEATURE , new ResourceLocation( Oreganized.MOD_ID , "lead_ore_savanna" ) , ORE_LEAD_SAVANNA );
+    private static List<PlacementModifier> orePlacement(int count, PlacementModifier modifier) {
+        return List.of(CountPlacement.of(count), InSquarePlacement.spread(), modifier, BiomeFilter.biome());
     }
 
-    @SubscribeEvent
-    public static void registerBiomeModification( final BiomeLoadingEvent event ) {
-        BiomeGenerationSettingsBuilder generation = event.getGeneration();
-        if (event.getCategory().equals( Biome.BiomeCategory.NETHER )) {
-            /*for(ConfiguredFeature<?, ?> ore : netherOres) {
-                if (ore != null) generation.withFeature(GenerationStage.Decoration.UNDERGROUND_ORES, ore);
-            }*/
-
-        } else if (event.getCategory().equals( Biome.BiomeCategory.THEEND )) {
-            /*for(ConfiguredFeature<?, ?> ore : endOres) {
-                if (ore != null) generation.withFeature(GenerationStage.Decoration.UNDERGROUND_ORES, ore);
-            }*/
-        } else if (event.getCategory().equals( Biome.BiomeCategory.SAVANNA )) {
-            generation.getFeatures( GenerationStep.Decoration.UNDERGROUND_ORES ).add( Holder.direct(ORE_LEAD_SAVANNA) );
-        } else {
-            //generation.getFeatures( GenerationStep.Decoration.UNDERGROUND_ORES ).add( () -> ORE_SILVER_OVERWORLD );
-            generation.getFeatures( GenerationStep.Decoration.UNDERGROUND_ORES ).add( Holder.direct(ORE_SILVER_DEEPSLATE_UP) );
-            generation.getFeatures( GenerationStep.Decoration.UNDERGROUND_ORES ).add( Holder.direct(ORE_SILVER_DEEPSLATE_DOWN) );
-            generation.getFeatures( GenerationStep.Decoration.UNDERGROUND_ORES ).add( Holder.direct(ORE_SILVER_UP) );
-            generation.getFeatures( GenerationStep.Decoration.UNDERGROUND_ORES ).add( Holder.direct(ORE_SILVER_DOWN) );
-            generation.getFeatures( GenerationStep.Decoration.UNDERGROUND_ORES ).add( Holder.direct(ORE_LEAD_DEEPSLATE_UP) );
-            generation.getFeatures( GenerationStep.Decoration.UNDERGROUND_ORES ).add( Holder.direct(ORE_LEAD_DEEPSLATE_DOWN) );
-        }
+    private static Holder<PlacedFeature> register(String key, Holder<? extends ConfiguredFeature<?, ?>> feature, List<PlacementModifier> modifiers) {
+        return PlacementUtils.register(new ResourceLocation(Oreganized.MOD_ID, key).toString(), feature, modifiers);
     }
 }
 


### PR DESCRIPTION
https://github.com/GL33P-0R4NG3/oreganized/blob/6a4722413eb6b78fad949af458b0f9e9b418d99b/src/main/java/me/gleep/oreganized/world/gen/OreganizedPlacedFeatures.java#L121 
By using Holder.direct, unlike other mods, you're skipping the configured feature by including it in the placed feature instead of a reference to it. This may seem fine when you play with the mod in game, but if you look at the resulting json file, it ends up all wrong. This can cause datapack issues.

Instead, you should follow vanilla and use PlacementUtils.register, storing the result in a Holder rather than just a PlacedFeature. You also need to put each ConfiguredFeature in a Holder for this to work. I made all these changes for you. I also moved the BiomeLoadingEvent modifications to your ModEvents class because autosubscribing them from the OreganizedPlacedFeatures class would attempt to register the placed and configured features before your mod's blocks are registered, which causes a null pointer exception.