### PR TITLE
Rough recipe patch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,71 +1,41 @@
 buildscript {
     repositories {
-        // These repositories are only for Gradle plugins, put any other repositories in the repository block further below
-        // zKryle (23/11/21) - don't worry about this parchment maven repo, it should be here, otherwise mappings won't work.
-        maven { url = 'https://maven.parchmentmc.org' }
         maven { url = 'https://maven.minecraftforge.net' }
         mavenCentral()
+        maven { url='https://repo.spongepowered.org/repository/maven-public/' }
+        maven { url = 'https://maven.parchmentmc.org' }
     }
     dependencies {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.1.+', changing: true
+        classpath 'org.spongepowered:mixingradle:0.7.+'
         classpath 'org.parchmentmc:librarian:1.+'
     }
 }
 
-plugins{
-    id 'java'
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
-}
-
 apply plugin: 'net.minecraftforge.gradle'
-// Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
-apply plugin: 'org.parchmentmc.librarian.forgegradle'
+//
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
+apply plugin: 'org.spongepowered.mixin'
+apply plugin: 'org.parchmentmc.librarian.forgegradle'
 
-version = '1.18.2-1.0.0-hotfix'
-group = 'me.gleep.oreganized' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = 'oreganized'
+version = project.oreganized_version
+group = 'me.gleep.oreganized.modid' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
+archivesBaseName = 'Oreganized_Mod-'+project.mc_version
 
-// Mojang ships Java 16 to end users in 1.17+ instead of Java 8 in 1.16 or lower, so your mod should target Java 16.
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
-println('Java: ' + System.getProperty('java.version') + ' JVM: ' + System.getProperty('java.vm.version') + '(' + System.getProperty('java.vendor') + ') Arch: ' + System.getProperty('os.arch'))
 minecraft {
-    // The mappings can be changed at any time and must be in the following format.
-    // Channel:   Version:
-    // snapshot   YYYYMMDD   Snapshot are built nightly.
-    // stable     #          Stables are built at the discretion of the MCP team.
-    // official   MCVersion  Official field/method names from Mojang mapping files
-    //
-    // You must be aware of the Mojang license when using the 'official' mappings.
-    // See more information here: https://github.com/MinecraftForge/MCPConfig/blob/master/Mojang.md
-    //
-    // Use non-default mappings at your own risk. They may not always work.
-    // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: 'parchment', version: '2022.03.13-1.18.2'
-    //mappings channel: 'official', version: '1.18.2'
+    mappings channel: 'parchment', version: project.parchment_version+'-'+project.mc_version
 
-
-    accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg') // Currently, this location cannot be changed from the default.
-
-    // Default run configurations.
-    // These can be tweaked, removed, or duplicated as needed.
     runs {
         client {
             workingDirectory project.file('run')
 
-            // Recommended logging data for a userdev environment
-            // The markers can be added/remove as needed separated by commas.
-            // "SCAN": For mods scan.
-            // "REGISTRIES": For firing of registry events.
-            // "REGISTRYDUMP": For getting the contents of all registries.
-            property 'forge.logging.markers', 'REGISTRIES'
+            //arg "-mixin.config=oreganized.mixins.json" // For if organized ever needs mixins
 
-            // Recommended logging level for the console
-            // You can set various levels here.
-            // Please read: https://stackoverflow.com/questions/2031163/when-to-use-the-different-log-levels
-            property 'forge.logging.console.level', 'debug'
+            //property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
+            //property 'forge.logging.console.level', 'debug'
 
             mods {
                 oreganized {
@@ -77,17 +47,10 @@ minecraft {
         server {
             workingDirectory project.file('run')
 
-            // Recommended logging data for a userdev environment
-            // The markers can be added/remove as needed separated by commas.
-            // "SCAN": For mods scan.
-            // "REGISTRIES": For firing of registry events.
-            // "REGISTRYDUMP": For getting the contents of all registries.
-            property 'forge.logging.markers', 'REGISTRIES'
+            //arg "-mixin.config=oreganized.mixins.json" // For if organized ever needs mixins
 
-            // Recommended logging level for the console
-            // You can set various levels here.
-            // Please read: https://stackoverflow.com/questions/2031163/when-to-use-the-different-log-levels
-            property 'forge.logging.console.level', 'debug'
+            //property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
+            //property 'forge.logging.console.level', 'debug'
 
             mods {
                 oreganized {
@@ -99,20 +62,12 @@ minecraft {
         data {
             workingDirectory project.file('run')
 
-            // Recommended logging data for a userdev environment
-            // The markers can be added/remove as needed separated by commas.
-            // "SCAN": For mods scan.
-            // "REGISTRIES": For firing of registry events.
-            // "REGISTRYDUMP": For getting the contents of all registries.
-            property 'forge.logging.markers', 'REGISTRIES'
+            //property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
+            //property 'forge.logging.console.level', 'debug'
 
-            // Recommended logging level for the console
-            // You can set various levels here.
-            // Please read: https://stackoverflow.com/questions/2031163/when-to-use-the-different-log-levels
-            property 'forge.logging.console.level', 'debug'
+            args '--mod', 'oreganized', '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/'), '--existing', file('src/generated/resources/')
 
-            // Specify the modid for data generation, where to output the resulting resource, and where to look for existing resources.
-            args '--mod', 'oreganized', '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
+            environment 'target', 'fmluserdevdata'
 
             mods {
                 oreganized {
@@ -121,48 +76,46 @@ minecraft {
             }
         }
     }
+    accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
 }
 
 // Include resources generated by data generators.
-sourceSets.main.resources { srcDir 'src/generated/resources' }
+sourceSets.main.resources {
+    srcDir 'src/generated/resources'
+}
 
 repositories {
-    // Put repositories for dependencies here
-    // ForgeGradle automatically adds the Forge maven and Maven Central for you
-    // If you have mod jar dependencies in ./libs, you can declare them as a repository like so:
-    // flatDir {
-    //     dir 'libs'
-    // }
+    maven {
+        url='https://repo.spongepowered.org/repository/maven-public/'
+    }
+    maven {
+        // location of the maven that hosts JEI files
+        name = "Progwml6 maven"
+        url = "https://dvs1.progwml6.com/files/maven/"
+    }
+    maven {
+        // location of a maven mirror for JEI files, as a fallback
+        name = "ModMaven"
+        url = "https://modmaven.k-4u.nl"
+    }
 }
 
 dependencies {
-    implementation 'org.jetbrains:annotations:20.1.0'
+    minecraft "net.minecraftforge:forge:${project.mc_version}-${project.forge_version}"
 
-    // Specify the version of Minecraft to use. If this is any group other than 'net.minecraft', it is assumed
-    // that the dep is a ForgeGradle 'patcher' dependency, and its patches will be applied.
-    // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.18.2-40.0.32'
+    compileOnly fg.deobf("mezz.jei:jei-${project.mc_version}:${jei_version}:api")
+    runtimeOnly fg.deobf("mezz.jei:jei-${project.mc_version}:${jei_version}")
 
-    // Real mod deobf dependency examples - these get remapped to your current mappings
-    // compileOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}:api") // Adds JEI API as a compile dependency
-    // runtimeOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}") // Adds the full JEI mod as a runtime dependency
-    // implementation fg.deobf("com.tterrag.registrate:Registrate:MC${mc_version}-${registrate_version}") // Adds registrate as a dependency
-    // Examples using mod jars from ./libs
-    // implementation fg.deobf("blank:coolmod-${mc_version}:${coolmod_version}")
-
-    // For more info...
-    // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
-    // http://www.gradle.org/docs/current/userguide/dependency_management.html
+    //annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 }
+/*
+mixin {
+    add sourceSets.main, "oreganized.refmap.json"
+    config 'oreganized.mixins.json'
+}
+ */
 
-// Example for how to get properties into the manifest for reading at runtime.
 
-// Example configuration to allow publishing using the maven-publish plugin
-// This is the preferred method to reobfuscate your jar file
-jar.finalizedBy('reobfJar')
-
-
-// Example for how to get properties into the manifest for reading at runtime.
 jar {
     manifest {
         attributes([
@@ -170,18 +123,15 @@ jar {
                 "Specification-Vendor"    : "oreganizedsareus",
                 "Specification-Version"   : "1", // We are version 1 of ourselves
                 "Implementation-Title"    : project.name,
-                "Implementation-Version"  : project.jar.archiveVersion,
+                "Implementation-Version"  : "${version}",
                 "Implementation-Vendor"   : "oreganizedsareus",
                 "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
+                //"MixinConfigs": "oreganized.mixins.json"
         ])
     }
 }
 
-// Example configuration to allow publishing using the maven-publish plugin
-// This is the preferred method to reobfuscate your jar file
 jar.finalizedBy('reobfJar')
-// However if you are in a multi-project build, dev time needs unobfed jar files, so you can delay the obfuscation until publishing by doing
-// publish.dependsOn('reobfJar')
 
 publishing {
     publications {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,7 @@
-# Sets default memory used for gradle commands. Can be overridden by user or command line properties.
-# This is required to provide enough memory for the Minecraft decompilation process.
-org.gradle.jvmargs=-Xmx3G
+org.gradle.jvmargs=-Xmx4G
 org.gradle.daemon=false
+oreganized_version=1.0.0
+mc_version=1.18.2
+forge_version=40.1.20
+parchment_version=2022.03.13
+jei_version=9.7.0.193

--- a/src/main/resources/data/oreganized/recipes/blast_deepslate_lead_ore.json
+++ b/src/main/resources/data/oreganized/recipes/blast_deepslate_lead_ore.json
@@ -1,0 +1,10 @@
+{
+  "type": "minecraft:blasting",
+  "group": "oreganized:lead_ingot",
+  "ingredient": {
+    "item": "oreganized:deepslate_lead_ore"
+  },
+  "result": "oreganized:lead_ingot",
+  "experience": 0.7,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/oreganized/recipes/blast_deepslate_silver_ore.json
+++ b/src/main/resources/data/oreganized/recipes/blast_deepslate_silver_ore.json
@@ -1,0 +1,10 @@
+{
+  "type": "minecraft:blasting",
+  "group": "oreganized:silver_ingot",
+  "ingredient": {
+    "item": "oreganized:deepslate_silver_ore"
+  },
+  "result": "oreganized:silver_ingot",
+  "experience": 0.7,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/oreganized/recipes/blast_lead_ore.json
+++ b/src/main/resources/data/oreganized/recipes/blast_lead_ore.json
@@ -1,0 +1,10 @@
+{
+  "type": "minecraft:blasting",
+  "group": "oreganized:lead_ingot",
+  "ingredient": {
+    "item": "oreganized:lead_ore"
+  },
+  "result": "oreganized:lead_ingot",
+  "experience": 0.7,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/oreganized/recipes/blast_silver_ore.json
+++ b/src/main/resources/data/oreganized/recipes/blast_silver_ore.json
@@ -1,0 +1,10 @@
+{
+  "type": "minecraft:blasting",
+  "group": "oreganized:silver_ingot",
+  "ingredient": {
+    "item": "oreganized:silver_ore"
+  },
+  "result": "oreganized:silver_ingot",
+  "experience": 0.7,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/oreganized/recipes/chiseled_glance.json
+++ b/src/main/resources/data/oreganized/recipes/chiseled_glance.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "A",
+    "A"
+  ],
+  "key": {
+    "A": {
+      "item": "oreganized:glance_slab"
+    }
+  },
+  "result": {
+    "item": "oreganized:chiseled_glance"
+  }
+}

--- a/src/main/resources/data/oreganized/recipes/chiseled_glance_stonecutting.json
+++ b/src/main/resources/data/oreganized/recipes/chiseled_glance_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "oreganized:glance"
+  },
+  "result": "oreganized:chiseled_glance",
+  "count": 1
+}

--- a/src/main/resources/data/oreganized/recipes/electrum_ingot.json
+++ b/src/main/resources/data/oreganized/recipes/electrum_ingot.json
@@ -1,20 +1,31 @@
 {
-  "type": "minecraft:crafting_shaped",
-  "pattern": [
-    "X#X",
-    "#X#",
-    "X#X"
-  ],
-  "key": {
-    "#": [
-      {
-        "item": "minecraft:gold_ingot"
-      }
-    ],
-    "X": {
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
       "item": "oreganized:silver_ingot"
+    },
+    {
+      "item": "oreganized:silver_ingot"
+    },
+    {
+      "item": "oreganized:silver_ingot"
+    },
+    {
+      "item": "oreganized:silver_ingot"
+    },
+    {
+      "item": "oreganized:silver_ingot"
+    },
+    {
+      "item": "minecraft:gold_ingot"
+    },
+    {
+      "item": "minecraft:gold_ingot"
+    },
+    {
+      "item": "minecraft:gold_ingot"
     }
-  },
+  ],
   "result": {
     "item": "oreganized:electrum_ingot"
   }

--- a/src/main/resources/data/oreganized/recipes/glance_brick_slab.json
+++ b/src/main/resources/data/oreganized/recipes/glance_brick_slab.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "AAA"
+  ],
+  "key": {
+    "A": {
+      "item": "oreganized:glance_bricks"
+    }
+  },
+  "result": {
+    "item": "oreganized:glance_bricks_slab",
+    "count": 6
+  }
+}

--- a/src/main/resources/data/oreganized/recipes/glance_brick_slab_stonecutting.json
+++ b/src/main/resources/data/oreganized/recipes/glance_brick_slab_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "oreganized:glance"
+  },
+  "result": "oreganized:glance_bricks_slab",
+  "count": 2
+}

--- a/src/main/resources/data/oreganized/recipes/glance_brick_stairs.json
+++ b/src/main/resources/data/oreganized/recipes/glance_brick_stairs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "A  ",
+    "AA ",
+    "AAA"
+  ],
+  "key": {
+    "M": {
+      "item": "oreganized:glance_bricks"
+    }
+  },
+  "result": {
+    "item": "oreganized:glance_bricks_stairs",
+    "count": 4
+  }
+}

--- a/src/main/resources/data/oreganized/recipes/glance_brick_stairs_stonecutting.json
+++ b/src/main/resources/data/oreganized/recipes/glance_brick_stairs_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "oreganized:glance"
+  },
+  "result": "oreganized:glance_bricks_stairs",
+  "count": 1
+}

--- a/src/main/resources/data/oreganized/recipes/glance_brick_wall.json
+++ b/src/main/resources/data/oreganized/recipes/glance_brick_wall.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "AAA",
+    "AAA"
+  ],
+  "key": {
+    "A": {
+      "item": "oreganized:glance_bricks"
+    }
+  },
+  "result": {
+    "item": "oreganized:glance_bricks_wall",
+    "count": 6
+  }
+}

--- a/src/main/resources/data/oreganized/recipes/glance_brick_wall_stonecutting.json
+++ b/src/main/resources/data/oreganized/recipes/glance_brick_wall_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "oreganized:glance"
+  },
+  "result": "oreganized:glance_bricks_wall",
+  "count": 1
+}

--- a/src/main/resources/data/oreganized/recipes/glance_bricks.json
+++ b/src/main/resources/data/oreganized/recipes/glance_bricks.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "AA",
+    "AA"
+  ],
+  "key": {
+    "A": {
+      "item": "oreganized:polished_glance"
+    }
+  },
+  "result": {
+    "item": "oreganized:glance_bricks",
+    "count": 4
+  }
+}

--- a/src/main/resources/data/oreganized/recipes/glance_bricks_stonecutting.json
+++ b/src/main/resources/data/oreganized/recipes/glance_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "oreganized:glance"
+  },
+  "result": "oreganized:glance_bricks",
+  "count": 1
+}

--- a/src/main/resources/data/oreganized/recipes/glance_bricks_to_glance_brick_slab_stonecutting.json
+++ b/src/main/resources/data/oreganized/recipes/glance_bricks_to_glance_brick_slab_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "oreganized:glance_bricks"
+  },
+  "result": "oreganized:glance_bricks_slab",
+  "count": 2
+}

--- a/src/main/resources/data/oreganized/recipes/glance_bricks_to_glance_brick_stairs_stonecutting.json
+++ b/src/main/resources/data/oreganized/recipes/glance_bricks_to_glance_brick_stairs_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "oreganized:glance_bricks"
+  },
+  "result": "oreganized:glance_bricks_stairs",
+  "count": 1
+}

--- a/src/main/resources/data/oreganized/recipes/glance_bricks_to_glance_brick_wall_stonecutting.json
+++ b/src/main/resources/data/oreganized/recipes/glance_bricks_to_glance_brick_wall_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "oreganized:glance_bricks"
+  },
+  "result": "oreganized:glance_bricks_wall",
+  "count": 1
+}

--- a/src/main/resources/data/oreganized/recipes/glance_slab.json
+++ b/src/main/resources/data/oreganized/recipes/glance_slab.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "AAA"
+  ],
+  "key": {
+    "A": {
+      "item": "oreganized:glance"
+    }
+  },
+  "result": {
+    "item": "oreganized:glance_slab",
+    "count": 6
+  }
+}

--- a/src/main/resources/data/oreganized/recipes/glance_slab_stonecutting.json
+++ b/src/main/resources/data/oreganized/recipes/glance_slab_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "oreganized:glance"
+  },
+  "result": "oreganized:glance_slab",
+  "count": 2
+}

--- a/src/main/resources/data/oreganized/recipes/glance_stairs.json
+++ b/src/main/resources/data/oreganized/recipes/glance_stairs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "A  ",
+    "AA ",
+    "AAA"
+  ],
+  "key": {
+    "A": {
+      "item": "oreganized:glance"
+    }
+  },
+  "result": {
+    "item": "oreganized:glance_stairs",
+    "count": 4
+  }
+}

--- a/src/main/resources/data/oreganized/recipes/glance_stairs_stonecutting.json
+++ b/src/main/resources/data/oreganized/recipes/glance_stairs_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "oreganized:glance"
+  },
+  "result": "oreganized:glance_stairs",
+  "count": 1
+}

--- a/src/main/resources/data/oreganized/recipes/glance_wall.json
+++ b/src/main/resources/data/oreganized/recipes/glance_wall.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "AAA",
+    "AAA"
+  ],
+  "key": {
+    "A": {
+      "item": "oreganized:glance"
+    }
+  },
+  "result": {
+    "item": "oreganized:glance_wall",
+    "count": 6
+  }
+}

--- a/src/main/resources/data/oreganized/recipes/glance_wall_stonecutting.json
+++ b/src/main/resources/data/oreganized/recipes/glance_wall_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "oreganized:glance"
+  },
+  "result": "oreganized:glance_wall",
+  "count": 1
+}

--- a/src/main/resources/data/oreganized/recipes/polished_glance.json
+++ b/src/main/resources/data/oreganized/recipes/polished_glance.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "AA",
+    "AA"
+  ],
+  "key": {
+    "M": {
+      "item": "oreganized:glance"
+    }
+  },
+  "result": {
+    "item": "oreganized:polished_glance",
+    "count": 4
+  }
+}

--- a/src/main/resources/data/oreganized/recipes/polished_glance_stonecutting.json
+++ b/src/main/resources/data/oreganized/recipes/polished_glance_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "oreganized:glance"
+  },
+  "result": "oreganized:polished_glance",
+  "count": 1
+}

--- a/src/main/resources/data/oreganized/recipes/shrapnel_bomb.json
+++ b/src/main/resources/data/oreganized/recipes/shrapnel_bomb.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "ABA",
+    "BAB",
+    "ABA"
+  ],
+  "key": {
+    "A": {
+      "item": "minecraft:gunpowder"
+    },
+    "B": {
+      "item": "oreganized:lead_nugget"
+    }
+  },
+  "result": {
+    "item": "oreganized:shrapnel_bomb"
+  }
+}

--- a/src/main/resources/data/oreganized/recipes/smelt_deepslate_lead_ore.json
+++ b/src/main/resources/data/oreganized/recipes/smelt_deepslate_lead_ore.json
@@ -1,0 +1,10 @@
+{
+  "type": "minecraft:smelting",
+  "group": "oreganized:lead_ingot",
+  "ingredient": {
+    "item": "oreganized:deepslate_lead_ore"
+  },
+  "result": "oreganized:lead_ingot",
+  "experience": 0.7,
+  "cookingtime": 200
+}

--- a/src/main/resources/data/oreganized/recipes/smelt_deepslate_silver_ore.json
+++ b/src/main/resources/data/oreganized/recipes/smelt_deepslate_silver_ore.json
@@ -1,0 +1,10 @@
+{
+  "type": "minecraft:smelting",
+  "group": "oreganized:silver_ingot",
+  "ingredient": {
+    "item": "oreganized:deepslate_silver_ore"
+  },
+  "result": "oreganized:silver_ingot",
+  "experience": 0.7,
+  "cookingtime": 200
+}

--- a/src/main/resources/data/oreganized/recipes/smelt_lead_ore.json
+++ b/src/main/resources/data/oreganized/recipes/smelt_lead_ore.json
@@ -1,0 +1,10 @@
+{
+  "type": "minecraft:smelting",
+  "group": "oreganized:lead_ingot",
+  "ingredient": {
+    "item": "oreganized:lead_ore"
+  },
+  "result": "oreganized:lead_ingot",
+  "experience": 0.7,
+  "cookingtime": 200
+}

--- a/src/main/resources/data/oreganized/recipes/smelt_silver_ore.json
+++ b/src/main/resources/data/oreganized/recipes/smelt_silver_ore.json
@@ -1,0 +1,10 @@
+{
+  "type": "minecraft:smelting",
+  "group": "oreganized:silver_ingot",
+  "ingredient": {
+    "item": "oreganized:silver_ore"
+  },
+  "result": "oreganized:silver_ingot",
+  "experience": 0.7,
+  "cookingtime": 200
+}

--- a/src/main/resources/data/oreganized/recipes/waxed_glance_spotted_from_honeycomb.json
+++ b/src/main/resources/data/oreganized/recipes/waxed_glance_spotted_from_honeycomb.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "oreganized:spotted_glance"
+    },
+    {
+      "item": "minecraft:honeycomb"
+    }
+  ],
+  "result": {
+    "item": "oreganized:waxed_spotted_glance"
+  }
+}


### PR DESCRIPTION
Added missing recipes including:
- All glance variants can now be crafted or stonecut as should be expected
- Waxed glance crafting recipe
- Smelting and Blasting recipes for silver and led ore blocks
- Added missing Shrapnel Bomb recipe

Changed electrum ingot recipe to be 5 silver ingots and 3 gold ingots

Changed up build.gradle (removing comments and utilising the gradle.propreties file) and added JEI to test runs to make it easier for testing recipes and such (not a proper dependency so won't effect public releases).

TODO: 
- Waxed Powdered Concrete crafting recipes (not a priority)
- Fix Silver Ore generation to be less common once I pull apart the code that's currently there